### PR TITLE
Add SDK and Toolkit links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Use Dejavu to mock network requests in Swift tests making them faster and more reliable. First use Dejavu to record network activity. From then on Dejavu can playback the original network request, exactly as it ran the first time. Dejavu stores requests and responses in a sqlite database.
 
+Dejavu is used to help test both the [ArcGIS Maps SDK for Swift](https://github.com/Esri/arcgis-maps-sdk-swift) and its associated [Toolkit](https://github.com/Esri/arcgis-maps-sdk-swift-toolkit).
+
 ## Example
 
 A full example of a mocked network test can be found [here](Examples/ExamplesTests/ExamplesTests.swift).


### PR DESCRIPTION
Adds links back to the maps SDK and Toolkit at the suggestion of Rachael from product outreach.