### PR TITLE
Update GRDB dependency to 6.29.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
-        "revision" : "5475dc98dca345be9447e6abdc35b7228bcac7bc",
-        "version" : "6.12.0"
+        "revision" : "dd6b98ce04eda39aa22f066cd421c24d7236ea8a",
+        "version" : "6.29.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/groue/GRDB.swift.git",
-            .upToNextMinor(from: "6.12.0")
+            .upToNextMinor(from: "6.29.1")
         )
     ],
     targets: [


### PR DESCRIPTION
This not only fixes warnings when building with Xcode 15.4, but errors when building with Xcode 16.0 Beta 5.