### PR TITLE
Modify how GRDB dependency is specified

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/groue/GRDB.swift.git",
-            .upToNextMinor(from: "6.29.1")
+            from: "6.29.1"
         )
     ],
     targets: [


### PR DESCRIPTION
The new way is the [recommended way](https://developer.apple.com/documentation/packagedescription/package/dependency/package(url:from:)#discussion):

> This is the recommended way to specify a remote package dependency. It allows you to specify the minimum version you require, allows updates that include bug fixes and backward-compatible feature updates, but requires you to explicitly update to a new major version of the dependency. This approach provides the maximum flexibility on which version to use, while making sure you don’t update to a version with breaking changes, and helps to prevent conflicts in your dependency graph.
