### PR TITLE
Fix multipart data bug

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,10 @@ let package = Package(
                 .enableExperimentalFeature("AccessLevelOnImport"),
                 .enableExperimentalFeature("StrictConcurrency")
             ]
+        ),
+        .testTarget(
+            name: "DejavuTests",
+            dependencies: ["Dejavu"]
         )
     ]
 )

--- a/Sources/Dejavu/DejavuSessionConfiguration.swift
+++ b/Sources/Dejavu/DejavuSessionConfiguration.swift
@@ -271,7 +271,7 @@ public final class DejavuSessionConfiguration: Sendable {
         }
         
         /// ASCII encoded strings with multipart bodies cannot be parsed.
-        if String(data: data, encoding: .ascii) != nil, ignoreMultipartRequestBody {
+        if data.isMultipartBody, ignoreMultipartRequestBody {
             // Return nil. Ignoring the filename portion of multipart request bodies is inconsistent.
             return nil
         }
@@ -410,5 +410,15 @@ private struct MultipartRequestBody {
     
     func normalizedData() -> Data {
         return normalized().data(using: .utf8)!
+    }
+}
+
+extension Data {
+    /// A Boolean value that indicates whether this data appears to be a multipart request body.
+    /// Note: This only checks a small prefix because sometimes the whole data
+    /// cannot be decoded into a string.
+    var isMultipartBody: Bool {
+        guard let prefixData = "\r\n--AaB03x".data(using: .ascii) else { return false }
+        return range(of: prefixData)?.lowerBound == 0
     }
 }

--- a/Tests/DejavuTests/DataTests.swift
+++ b/Tests/DejavuTests/DataTests.swift
@@ -1,0 +1,40 @@
+// Copyright 2024 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import Dejavu
+import XCTest
+
+final class DataTests: XCTestCase {
+    func testIsMultipartBody() throws {
+        let validMultipartData = ("\r" + """
+
+        --AaB03x
+        Content-Disposition: form-data; name="name"
+        """).data(using: .ascii)!
+        XCTAssertTrue(validMultipartData.isMultipartBody)
+        
+        let unknownBoundryStringMultipartData = ("\r" + """
+
+        --abc123
+        Content-Disposition: form-data; name="name"
+        """).data(using: .ascii)!
+        XCTAssertFalse(unknownBoundryStringMultipartData.isMultipartBody)
+        
+        let noBoundryStringMultipartData = ("\r" + """
+        
+        Content-Disposition: form-data; name="name"
+        """).data(using: .ascii)!
+        XCTAssertFalse(noBoundryStringMultipartData.isMultipartBody)
+    }
+}


### PR DESCRIPTION
Swift #6159

It looks like in iOS 18.0 multipart data can no longer be encoded using ascii which resulted in requests having different hash values which shouldn't happen if `ignoreMultipartRequestBody` is true. This solution was from @rolson and it is just another way of checking if the data is multipart by checking if there is a boundary string at the beginning of the data.