### PR TITLE
Add SupplementalRecordBehavior to denote whether to update existing instances or insert new ones

### DIFF
--- a/Sources/Dejavu/Dejavu.swift
+++ b/Sources/Dejavu/Dejavu.swift
@@ -34,7 +34,7 @@ public enum Dejavu {
         let session = try GRDBSession(configuration: configuration)
         _currentSession.withLock { $0 = session }
         
-        session.begin()
+        try session.begin()
         
         log("Dejavu session started", category: .beginSession, type: .info)
         

--- a/Sources/Dejavu/DejavuSessionConfiguration.swift
+++ b/Sources/Dejavu/DejavuSessionConfiguration.swift
@@ -20,20 +20,26 @@ internal import os
 /// needed to start a new session.
 public final class DejavuSessionConfiguration: Sendable {
     /// A mode of operation for the Dejavu session.
-    public enum Mode: Sendable {
+    public enum Mode: Equatable, Sendable {
         /// First deletes the cache, then records any network traffic to the
         /// cache.
         case cleanRecord
         
-        /// When supplemental recording, we can either update existing request instances or insert new instances for matching requests.
+        /// When supplemental recording, we can either update existing request instances or
+        /// insert new instances for matching requests.
         public enum SupplementalRecordBehavior: Sendable, Equatable {
             case updateExisting
             case insertNew
         }
         
         /// Records any network traffic to the cache. Does not delete the
-        /// database first. Will either update existing request instances or insert new instances for matching requests.
-        case supplementalRecord(_ behavior: SupplementalRecordBehavior = .updateExisting)
+        /// database first.
+        case supplementalRecord(_ behavior: SupplementalRecordBehavior)
+        /// This is equivalent to `supplementalRecord(.updateExisting)`.
+        static var supplementalRecord: Self {
+            .supplementalRecord(.updateExisting)
+        }
+        
         /// Intercepts requests and gets the responses from the cache.
         case playback
     }

--- a/Sources/Dejavu/DejavuSessionConfiguration.swift
+++ b/Sources/Dejavu/DejavuSessionConfiguration.swift
@@ -36,7 +36,7 @@ public final class DejavuSessionConfiguration: Sendable {
         /// database first.
         case supplementalRecord(_ behavior: SupplementalRecordBehavior)
         /// This is equivalent to `supplementalRecord(.updateExisting)`.
-        static var supplementalRecord: Self {
+        public static var supplementalRecord: Self {
             .supplementalRecord(.updateExisting)
         }
         

--- a/Sources/Dejavu/DejavuSessionConfiguration.swift
+++ b/Sources/Dejavu/DejavuSessionConfiguration.swift
@@ -24,9 +24,16 @@ public final class DejavuSessionConfiguration: Sendable {
         /// First deletes the cache, then records any network traffic to the
         /// cache.
         case cleanRecord
+        
+        /// When supplemental recording, we can either update existing request instances or insert new instances for matching requests.
+        public enum SupplementalRecordBehavior: Sendable, Equatable {
+            case updateExisting
+            case insertNew
+        }
+        
         /// Records any network traffic to the cache. Does not delete the
-        /// database first.
-        case supplementalRecord
+        /// database first. Will either update existing request instances or insert new instances for matching requests.
+        case supplementalRecord(_ behavior: SupplementalRecordBehavior = .updateExisting)
         /// Intercepts requests and gets the responses from the cache.
         case playback
     }

--- a/Sources/Dejavu/DejavuSessionConfiguration.swift
+++ b/Sources/Dejavu/DejavuSessionConfiguration.swift
@@ -35,6 +35,7 @@ public final class DejavuSessionConfiguration: Sendable {
         /// Records any network traffic to the cache. Does not delete the
         /// database first.
         case supplementalRecord(_ behavior: SupplementalRecordBehavior)
+        
         /// This is equivalent to `supplementalRecord(.updateExisting)`.
         public static var supplementalRecord: Self {
             .supplementalRecord(.updateExisting)

--- a/Sources/Dejavu/GRDBSession.swift
+++ b/Sources/Dejavu/GRDBSession.swift
@@ -204,20 +204,17 @@ final class GRDBSession: DejavuSession, @unchecked Sendable {
         return (data: data, response: response)
     }
     
-    func begin() {
+    func begin() throws {
         switch configuration.mode {
         case .playback:
             configuration.networkInterceptor.startIntercepting(handler: self)
         case .cleanRecord, .supplementalRecord:
-            // when supplemental recording and we want to insert new instances, we need to populate previous instance counts from dbQueue
-            if case let .supplementalRecord(behavior) = self.configuration.mode, behavior == .insertNew {
-                state.withLock { state in
-                    do {
-                        state.instanceCounts = try dbQueue.read { db in
-                            try db.queryInstanceCounts()
-                        }
-                    } catch {
-                        log("Error loading instance counts: \(error)", type: .error)
+            // when supplemental recording and we want to insert new instances,
+            // we need to populate previous instance counts from dbQueue
+            if configuration.mode == .supplementalRecord(.insertNew) {
+                try state.withLock { state in
+                    state.instanceCounts = try dbQueue.read { db in
+                        try db.instanceCounts
                     }
                 }
             }
@@ -515,17 +512,20 @@ extension GRDBSession: DejavuNetworkObservationHandler {
 }
 
 extension Database {
-    func queryInstanceCounts() throws -> [String: Int] {
-        var instanceCounts: [String: Int] = [:]
-        let rows = try Row.fetchAll(self, sql: "SELECT hash, MAX(instance) as instanceCount FROM requests GROUP BY hash")
-        for row in rows {
-            let hash: String = row["hash"]
-            let instanceCount: Int = row["instanceCount"]
-            instanceCounts[hash] = instanceCount
+    // Returns maximum instance counts for all request hashes
+    var instanceCounts: [String: Int] {
+        get throws {
+            let rows = try Row.fetchAll(
+                self,
+                sql: "SELECT hash, MAX(instance) as instanceCount FROM requests GROUP BY hash"
+            )
+            return .init(
+                uniqueKeysWithValues: rows.lazy
+                    .map { ($0["hash"], $0["instanceCount"]) }
+            )
         }
-        return instanceCounts
     }
-
+    
     func record(for request: Request, instanceCount: Int, instanceCountBehavior: DejavuSessionConfiguration.InstanceCountBehavior = .strict) throws -> GRDBSession.RequestRecord? {
         // create a record, so that it will normalize and then it can be used find the desired one
         let tmp = GRDBSession.RequestRecord(request: request, instance: Int64(instanceCount))


### PR DESCRIPTION
We use Dejavu for UI Tests, including workflows where the application under test needs to be killed / restarted. In `.cleanRecord` mode, the clearing of database cache means the database will get deleted on application restart while the test is still running. Therefore, we actually have to use `.supplementalRecord` for our tests so that we can continue recording to an existing database between kill / restarts. The downside is that the default behavior will update previous requests following the restart due to the instanceCounts counter being reset between application launches.

The approach below, allows us to set mode to `.supplementalRecord(.insertNew)`, which will re-hydrate the instanceCounts each time the Dejavu session begins

Here is the flow for how we are using Dejavu in the UI tests
1. Dejavu session started on ContentView.init() on app launch
2. Test does stuff
3. Test kills / restarts app, resulting in previous Dejavu session being ended and a new one started
   - _Note: we explicitly end session before killing app so that in-memory db written to file_
4. Test does other stuff
   - _Note: we use `.supplementalRecord`, so that we can continue writing to same db following relaunch_
   -  **Without changes below, any matching requests from step 2 will be overwritten as they get updated**
   -  **With changes below, we can use `.supplementalRecord(.insertNew)` to continue appending new instances rather than updating previous ones**