### PR TITLE
fix concurrency error

### DIFF
--- a/Sources/Dejavu/URLProtocolNetworkObserver.swift
+++ b/Sources/Dejavu/URLProtocolNetworkObserver.swift
@@ -65,7 +65,9 @@ extension URLProtocolNetworkObserver: DejavuNetworkObserver {
 
 final class ObserverProtocol: URLProtocol, @unchecked Sendable {
     static let session = URLSession(configuration: .ephemeral)
-    
+
+    private var dataTask: URLSessionDataTask?
+
     override class func canInit(with request: URLRequest) -> Bool {
         let hasHandler = URLProtocolNetworkObserver.shared.handler != nil
         if !hasHandler {
@@ -83,26 +85,61 @@ final class ObserverProtocol: URLProtocol, @unchecked Sendable {
             log("canInit called with no handler", type: .error)
             return
         }
-        
-        Task.detached {
-            guard let client = self.client else { return }
-            
-            let identifier = UUID().uuidString
-            handler.requestWillBeSent(identifier: identifier, request: self.request)
-            
-            do {
-                let (data, response) = try await Self.session.data(for: self.request)
+
+        guard let client else { return }
+
+        let identifier = UUID().uuidString
+        let clientBridge = ClientBridge(client: client, urlProtocol: self)
+
+        handler.requestWillBeSent(identifier: identifier, request: request)
+
+        let dataTask = Self.session.dataTask(with: request) { [clientBridge, handler, identifier] data, response, error in
+            if let response {
                 handler.responseReceived(identifier: identifier, response: response)
-                client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-                client.urlProtocol(self, didLoad: data)
-                client.urlProtocolDidFinishLoading(self)
+                clientBridge.didReceive(response)
+            }
+
+            if let error {
+                clientBridge.didFail(with: error)
+                handler.requestFinished(identifier: identifier, result: .failure(error))
+            } else if let data {
+                clientBridge.didLoad(data)
+                clientBridge.didFinishLoading()
                 handler.requestFinished(identifier: identifier, result: .success(data))
-            } catch {
-                client.urlProtocol(self, didFailWithError: error)
+            } else {
+                let error = URLError(.badServerResponse)
+                clientBridge.didFail(with: error)
                 handler.requestFinished(identifier: identifier, result: .failure(error))
             }
         }
+
+        self.dataTask = dataTask
+        dataTask.resume()
     }
-    
-    override func stopLoading() {}
+
+    override func stopLoading() {
+        dataTask?.cancel()
+        dataTask = nil
+    }
+}
+
+private struct ClientBridge: @unchecked Sendable {
+    let client: any URLProtocolClient
+    let urlProtocol: ObserverProtocol
+
+    func didReceive(_ response: URLResponse) {
+        client.urlProtocol(urlProtocol, didReceive: response, cacheStoragePolicy: .notAllowed)
+    }
+
+    func didLoad(_ data: Data) {
+        client.urlProtocol(urlProtocol, didLoad: data)
+    }
+
+    func didFinishLoading() {
+        client.urlProtocolDidFinishLoading(urlProtocol)
+    }
+
+    func didFail(with error: any Error) {
+        client.urlProtocol(urlProtocol, didFailWithError: error)
+    }
 }


### PR DESCRIPTION
## Summary

Fix Swift 6 concurrency diagnostics in `URLProtocolNetworkObserver` by replacing the detached async/await request flow with a `URLSessionDataTask`-based implementation.

## Problem

`ObserverProtocol.startLoading()` previously used `Task.detached` and captured `self`, `self.client`, and `self.request` inside the detached closure. Under Swift 6’s stricter concurrency checking, that produced:

> Passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure

The issue is that `Task.detached` treats its closure as crossing an isolation boundary, so capturing the live `URLProtocol` instance and related mutable state is considered unsafe.

## Fix

This change removes the detached task-based implementation and restores a `URLSession.dataTask(with:)` flow in `ObserverProtocol`.

Key changes:
- Replaced `Task.detached { ... await session.data(for:) ... }` with `session.dataTask(with: request)`.
- Stored the created `URLSessionDataTask` on the protocol instance so it can be cancelled from `stopLoading()`.
- Routed client callbacks through a small sendable bridge object instead of directly sending the active `URLProtocol` instance through a detached task.
- Preserved the existing event order:
  - `requestWillBeSent`
  - `responseReceived`
  - `requestFinished`

## Why this works

This avoids the Swift 6 warning because we are no longer passing a closure to `Task.detached` that sends `self` into concurrently executing work.

Instead:
- `URLSessionDataTask` handles the asynchronous network execution.
- The completion handler uses captured values that are explicitly structured for this callback path.
- `stopLoading()` now cancels the in-flight task, which better matches `URLProtocol` lifecycle expectations.

In short, the fix removes the unsafe concurrency boundary that Swift was warning about, while keeping the observer behavior the same.
